### PR TITLE
Remove AWS providers

### DIFF
--- a/terraform/api/aws/main.tf
+++ b/terraform/api/aws/main.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 2.49"
+  version = "~> 3.0"
 }
 
 provider "kubernetes" {

--- a/terraform/api/aws/main.tf
+++ b/terraform/api/aws/main.tf
@@ -2,10 +2,6 @@ terraform {
   required_version = ">= 0.12.0"
 }
 
-provider "kubernetes" {
-  version = "~> 1.11"
-}
-
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 

--- a/terraform/api/aws/main.tf
+++ b/terraform/api/aws/main.tf
@@ -15,10 +15,6 @@ locals {
 module "k8s" {
   source = "../k8s"
 
-  providers = {
-    kubernetes = kubernetes
-  }
-
   domain    = var.domain
   namespace = var.namespace
   rack      = var.name

--- a/terraform/api/aws/main.tf
+++ b/terraform/api/aws/main.tf
@@ -2,10 +2,6 @@ terraform {
   required_version = ">= 0.12.0"
 }
 
-provider "aws" {
-  version = "~> 3.0"
-}
-
 provider "kubernetes" {
   version = "~> 1.11"
 }

--- a/terraform/api/k8s/main.tf
+++ b/terraform/api/k8s/main.tf
@@ -1,7 +1,3 @@
-provider "kubernetes" {
-  version = "~> 1.11"
-}
-
 provider "random" {
   version = "~> 2.2"
 }

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 2.49"
+  version = "~> 3.0"
 }
 
 provider "kubernetes" {

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -2,16 +2,6 @@ terraform {
   required_version = ">= 0.12.0"
 }
 
-provider "kubernetes" {
-  version = "~> 1.11"
-
-  cluster_ca_certificate = base64decode(aws_eks_cluster.cluster.certificate_authority.0.data)
-  host                   = aws_eks_cluster.cluster.endpoint
-  token                  = data.aws_eks_cluster_auth.cluster.token
-
-  load_config_file = false
-}
-
 provider "local" {
   version = "~> 1.3"
 }

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -2,10 +2,6 @@ terraform {
   required_version = ">= 0.12.0"
 }
 
-provider "aws" {
-  version = "~> 3.0"
-}
-
 provider "kubernetes" {
   version = "~> 1.11"
 

--- a/terraform/cluster/aws/outputs.tf
+++ b/terraform/cluster/aws/outputs.tf
@@ -34,3 +34,7 @@ output "subnets" {
 output "vpc" {
   value = aws_vpc.nodes.id
 }
+
+output "token" {
+  value = data.aws_eks_cluster_auth.cluster.token
+}

--- a/terraform/fluentd/aws/main.tf
+++ b/terraform/fluentd/aws/main.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 2.49"
+  version = "~> 3.0"
 }
 
 provider "kubernetes" {

--- a/terraform/fluentd/aws/main.tf
+++ b/terraform/fluentd/aws/main.tf
@@ -2,10 +2,6 @@ terraform {
   required_version = ">= 0.12.0"
 }
 
-provider "kubernetes" {
-  version = "~> 1.11"
-}
-
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 

--- a/terraform/fluentd/aws/main.tf
+++ b/terraform/fluentd/aws/main.tf
@@ -2,10 +2,6 @@ terraform {
   required_version = ">= 0.12.0"
 }
 
-provider "aws" {
-  version = "~> 3.0"
-}
-
 provider "kubernetes" {
   version = "~> 1.11"
 }

--- a/terraform/fluentd/aws/main.tf
+++ b/terraform/fluentd/aws/main.tf
@@ -15,10 +15,6 @@ locals {
 module "k8s" {
   source = "../k8s"
 
-  providers = {
-    kubernetes = kubernetes
-  }
-
   cluster   = var.cluster
   image     = "convox/fluentd:1.7"
   namespace = var.namespace

--- a/terraform/rack/aws/main.tf
+++ b/terraform/rack/aws/main.tf
@@ -3,8 +3,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 2.49"
-}
+  version = "~> 3.0"
 
 provider "external" {
   version = "~> 1.2"

--- a/terraform/rack/aws/main.tf
+++ b/terraform/rack/aws/main.tf
@@ -4,6 +4,7 @@ terraform {
 
 provider "aws" {
   version = "~> 3.0"
+}
 
 provider "external" {
   version = "~> 1.2"

--- a/terraform/rack/aws/main.tf
+++ b/terraform/rack/aws/main.tf
@@ -26,7 +26,6 @@ module "api" {
   source = "../../api/aws"
 
   providers = {
-    aws        = aws
     kubernetes = kubernetes
   }
 
@@ -52,7 +51,6 @@ module "resolver" {
   source = "../../resolver/aws"
 
   providers = {
-    aws        = aws
     kubernetes = kubernetes
   }
 
@@ -65,7 +63,6 @@ module "router" {
   source = "../../router/aws"
 
   providers = {
-    aws        = aws
     kubernetes = kubernetes
   }
 

--- a/terraform/rack/aws/main.tf
+++ b/terraform/rack/aws/main.tf
@@ -9,10 +9,6 @@ provider "external" {
 module "k8s" {
   source = "../k8s"
 
-  providers = {
-    kubernetes = kubernetes
-  }
-
   domain  = module.router.endpoint
   name    = var.name
   release = var.release
@@ -20,10 +16,6 @@ module "k8s" {
 
 module "api" {
   source = "../../api/aws"
-
-  providers = {
-    kubernetes = kubernetes
-  }
 
   domain    = module.router.endpoint
   name      = var.name
@@ -38,17 +30,10 @@ module "api" {
 module "metrics" {
   source = "../../metrics/k8s"
 
-  providers = {
-    kubernetes = kubernetes
-  }
 }
 
 module "resolver" {
   source = "../../resolver/aws"
-
-  providers = {
-    kubernetes = kubernetes
-  }
 
   namespace = module.k8s.namespace
   rack      = var.name
@@ -57,10 +42,6 @@ module "resolver" {
 
 module "router" {
   source = "../../router/aws"
-
-  providers = {
-    kubernetes = kubernetes
-  }
 
   name      = var.name
   namespace = module.k8s.namespace

--- a/terraform/rack/aws/main.tf
+++ b/terraform/rack/aws/main.tf
@@ -6,10 +6,6 @@ provider "external" {
   version = "~> 1.2"
 }
 
-provider "kubernetes" {
-  version = "~> 1.11"
-}
-
 module "k8s" {
   source = "../k8s"
 

--- a/terraform/rack/aws/main.tf
+++ b/terraform/rack/aws/main.tf
@@ -2,10 +2,6 @@ terraform {
   required_version = ">= 0.12.0"
 }
 
-provider "aws" {
-  version = "~> 3.0"
-}
-
 provider "external" {
   version = "~> 1.2"
 }

--- a/terraform/resolver/aws/main.tf
+++ b/terraform/resolver/aws/main.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 2.49"
+  version = "~> 3.0"
 }
 
 provider "kubernetes" {

--- a/terraform/resolver/aws/main.tf
+++ b/terraform/resolver/aws/main.tf
@@ -5,10 +5,6 @@ terraform {
 module "k8s" {
   source = "../k8s"
 
-  providers = {
-    kubernetes = kubernetes
-  }
-
   namespace = var.namespace
   rack      = var.rack
   release   = var.release

--- a/terraform/resolver/aws/main.tf
+++ b/terraform/resolver/aws/main.tf
@@ -2,10 +2,6 @@ terraform {
   required_version = ">= 0.12.0"
 }
 
-provider "kubernetes" {
-  version = "~> 1.11"
-}
-
 module "k8s" {
   source = "../k8s"
 

--- a/terraform/resolver/aws/main.tf
+++ b/terraform/resolver/aws/main.tf
@@ -2,10 +2,6 @@ terraform {
   required_version = ">= 0.12.0"
 }
 
-provider "aws" {
-  version = "~> 3.0"
-}
-
 provider "kubernetes" {
   version = "~> 1.11"
 }

--- a/terraform/router/aws/main.tf
+++ b/terraform/router/aws/main.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 2.49"
+  version = "~> 3.0"
 }
 
 provider "http" {

--- a/terraform/router/aws/main.tf
+++ b/terraform/router/aws/main.tf
@@ -2,10 +2,6 @@ terraform {
   required_version = ">= 0.12.0"
 }
 
-provider "aws" {
-  version = "~> 3.0"
-}
-
 provider "http" {
   version = "~> 1.1"
 }

--- a/terraform/router/aws/main.tf
+++ b/terraform/router/aws/main.tf
@@ -6,10 +6,6 @@ provider "http" {
   version = "~> 1.1"
 }
 
-provider "kubernetes" {
-  version = "~> 1.11"
-}
-
 locals {
   tags = {
     System = "convox"

--- a/terraform/router/aws/main.tf
+++ b/terraform/router/aws/main.tf
@@ -19,10 +19,6 @@ data "aws_region" "current" {
 module "nginx" {
   source = "../nginx"
 
-  providers = {
-    kubernetes = kubernetes
-  }
-
   namespace = var.namespace
   rack      = var.name
 }

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 2.49"
+  version = "~> 3.0"
 
   region = var.region
 }

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -28,10 +28,6 @@ module "cluster" {
 module "fluentd" {
   source = "../../fluentd/aws"
 
-  providers = {
-    kubernetes = kubernetes
-  }
-
   cluster   = module.cluster.id
   namespace = "kube-system"
   oidc_arn  = module.cluster.oidc_arn
@@ -42,10 +38,6 @@ module "fluentd" {
 
 module "rack" {
   source = "../../rack/aws"
-
-  providers = {
-    kubernetes = kubernetes
-  }
 
   cluster   = module.cluster.id
   name      = var.name

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -1,9 +1,3 @@
-provider "aws" {
-  version = "~> 3.0"
-
-  region = var.region
-}
-
 provider "http" {
   version = "~> 1.1"
 }

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -2,16 +2,6 @@ provider "http" {
   version = "~> 1.1"
 }
 
-provider "kubernetes" {
-  version = "~> 1.11"
-
-  cluster_ca_certificate = module.cluster.ca
-  host                   = module.cluster.endpoint
-  token                  = data.aws_eks_cluster_auth.cluster.token
-
-  load_config_file = false
-}
-
 data "aws_eks_cluster_auth" "cluster" {
   name = module.cluster.id
 }

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -28,10 +28,6 @@ locals {
 module "cluster" {
   source = "../../cluster/aws"
 
-  providers = {
-    aws = aws
-  }
-
   cidr      = var.cidr
   name      = var.name
   node_disk = var.node_disk
@@ -43,7 +39,6 @@ module "fluentd" {
   source = "../../fluentd/aws"
 
   providers = {
-    aws        = aws
     kubernetes = kubernetes
   }
 
@@ -59,7 +54,6 @@ module "rack" {
   source = "../../rack/aws"
 
   providers = {
-    aws        = aws
     kubernetes = kubernetes
   }
 


### PR DESCRIPTION
Remove providers call so that the modules can be directly called from our codebase with specifically configured provider configs and version constraints